### PR TITLE
fix: support raspberry pi 4 arm compile

### DIFF
--- a/utilities/transactions/lock/range/range_tree/lib/portability/toku_time.h
+++ b/utilities/transactions/lock/range/range_tree/lib/portability/toku_time.h
@@ -131,6 +131,10 @@ static inline tokutime_t toku_time_now(void) {
   uint64_t result;
   __asm __volatile__("mrs %[rt], cntvct_el0" : [ rt ] "=r"(result));
   return result;
+#elif defined(__arm__)
+   uint32_t lo, hi;
+   __asm __volatile__("mrrc p15, 1, %[lo], %[hi], c14" : [ lo ] "=r" (lo), [hi] "=r" (hi));
+   return (uint64_t)hi << 32 | lo;
 #elif defined(__powerpc__)
   return __ppc_get_timebase();
 #elif defined(__s390x__)


### PR DESCRIPTION
Apply arm compile for raspberry pi 4

This change is essential to use the latest python-rocksdb v0.7.

This changes is reference from https://github.com/dpeuscher/rocksdb/commit/4c5c268b666da0615a1c64dc626fd3e5a7b59b0c (https://github.com/facebook/rocksdb/issues/8609 `Add armv7 support`)
Thank you @dpeuscher

